### PR TITLE
build: Fix Python version references for tox-gh-actions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,9 @@ envlist = gitlint,py{38,39},flake8
 
 [gh-actions]
 python =
-    '3.8': gitlint,py38,flake8
-    '3.9': gitlint,py39,flake8
-    '3.10': gitlint,py310,flake8
+    3.8: gitlint,py38,flake8
+    3.9: gitlint,py39,flake8
+    3.10: gitlint,py310,flake8
 
 [flake8]
 ignore = E124,W504


### PR DESCRIPTION
`tox-gh-actions` needs the version numbers in the `python-version` matrix (in the workflow definition) with single quotes, but unquoted in `tox.ini`.

Reference:
https://github.com/ymyzk/tox-gh-actions#readme