### PR TITLE
Fix db access and volumes

### DIFF
--- a/tutorenrollmentreports/patches/k8s-jobs
+++ b/tutorenrollmentreports/patches/k8s-jobs
@@ -19,8 +19,10 @@ spec:
                 - 'enrollment-report.yml'
               volumeMounts:
                 - name: enrollmentreports-mysql-config
+                  subPath: my.cnf
                   mountPath: '/root/.my.cnf'
                 - name: enrollmentreports-inventory-config
+                  subPath: config.yml
                   mountPath: '/etc/ansible/group_vars/all'
           volumes:
             - name: enrollmentreports-mysql-config

--- a/tutorenrollmentreports/templates/enrollmentreports/build/enrollmentreports/mysql_config/my.cnf
+++ b/tutorenrollmentreports/templates/enrollmentreports/build/enrollmentreports/mysql_config/my.cnf
@@ -1,5 +1,5 @@
 [client]
 host={{ MYSQL_HOST }}
 port={{ MYSQL_PORT }}
-user={{ MYSQL_ROOT_USERNAME }}
-password={{ MYSQL_ROOT_PASSWORD }}
+user={{ OPENEDX_MYSQL_USERNAME }}
+password={{ OPENEDX_MYSQL_PASSWORD }}


### PR DESCRIPTION
* Use the `openedx` user, not `root`, to access the database for fetching enrollment reports
* Fix the ConfigMap volume `subMount` properties to make the playbooks run at all. 