### PR TITLE
fix: Limit the plugin to Open edX Maple release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
     python_requires=">=3.6",
-    install_requires=["tutor"],
+    install_requires=["tutor<14"],
     setup_requires=["setuptools-scm"],
     entry_points={
         "tutor.plugin.v0": [


### PR DESCRIPTION
From version 14, Tutor uses the Open edX Nutmeg release. Until we add
support for that release, limit the plugin to Tutor versions <14.