### PR TITLE
Make the report frequency configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ You must
   the job pod (set this to an image reference in your local registry,
   unless your Tutor configuration already sets `DOCKER_REGISTRY` to
   point to that)
+* `ENROLLMENTREPORTS_FREQUENCY`: the frequency with which enrollment
+  reports are generated (default `monthly`)
 * `ENROLLMENTREPORTS_K8S_CRONJOB_SCHEDULE` (default `"0 0 1 * *"`,
   that is once a month at midnight, on the first day of the month)
 

--- a/tutorenrollmentreports/plugin.py
+++ b/tutorenrollmentreports/plugin.py
@@ -15,6 +15,8 @@ config = {
     "defaults": {
         "VERSION": __version__,
         "DOCKER_IMAGE": "{{ DOCKER_REGISTRY }}enrollmentreports:{{ ENROLLMENTREPORTS_VERSION }}",  # noqa: E501
+        "REPOSITORY": "https://github.com/hastexo/ansible-role-enrollmentreports.git",  # noqa: E501
+        "REVISION": "main",
         "MAIL_FROM": "{{ SMTP_USERNAME }}",
         "K8S_CRONJOB_SCHEDULE": "0 0 1 * *",
     },

--- a/tutorenrollmentreports/plugin.py
+++ b/tutorenrollmentreports/plugin.py
@@ -18,6 +18,7 @@ config = {
         "REPOSITORY": "https://github.com/hastexo/ansible-role-enrollmentreports.git",  # noqa: E501
         "REVISION": "main",
         "MAIL_FROM": "{{ SMTP_USERNAME }}",
+        "FREQUENCY": "monthly",
         "K8S_CRONJOB_SCHEDULE": "0 0 1 * *",
     },
 }

--- a/tutorenrollmentreports/templates/enrollmentreports/build/enrollmentreports/Dockerfile
+++ b/tutorenrollmentreports/templates/enrollmentreports/build/enrollmentreports/Dockerfile
@@ -3,5 +3,6 @@ RUN mkdir -p /etc/ansible/roles/enrollmentreports /etc/ansible/group_vars
 RUN apt-get update && \
     apt install -y ansible git default-mysql-client rsync
 
-RUN git -C /etc/ansible/roles clone https://github.com/hastexo/ansible-role-enrollmentreports.git enrollmentreports
+RUN git -C /etc/ansible/roles clone {{ ENROLLMENTREPORTS_REPOSITORY }} enrollmentreports
+RUN git -C /etc/ansible/roles/enrollmentreports checkout {{ ENROLLMENTREPORTS_REVISION }}
 COPY enrollment-report.yml .

--- a/tutorenrollmentreports/templates/enrollmentreports/build/enrollmentreports/inventory/config.yml
+++ b/tutorenrollmentreports/templates/enrollmentreports/build/enrollmentreports/inventory/config.yml
@@ -2,6 +2,7 @@ enrollment_report_hostname: "{{ LMS_HOST }}"
 enrollment_report_database: "{{ OPENEDX_MYSQL_DATABASE }}"
 {% if RUN_SMTP or SMTP_HOST %}
 enrollment_report_mail_enable: true
+enrollment_report_frequency: "{{ ENROLLMENTREPORTS_FREQUENCY }}"
 enrollment_report_mail_from: "{{ ENROLLMENTREPORTS_MAIL_FROM }}"
 enrollment_report_mail_to: {{ ENROLLMENTREPORTS_MAIL_TO }}
 enrollment_report_mail_host: "{{ SMTP_HOST }}"


### PR DESCRIPTION
- feat: Enable setting the enrollment reports frequency
In hastexo/ansible-role-enrollmentreports#5, we introduce the ability to set the enrollment report frequency to either `weekly` or `monthly`.
- feat: Make the Ansible role repository configurable
In order to facilitate testing, also add the ability to select a custom repo/fork as the source of the Ansible role, and/or select a specific branch/tag/revision.