### PR TITLE
feat: Add ability to enable and disable CronJobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+* [feature] Add ability to enable and disable the Kubernetes CronJob
+  by suspending them (with `ENROLLMENTREPORTS_K8S_CRONJOB_ENABLE`).
+
 ## Version 1.1.0 (2023-02-14)
 
 * Add the ability to set the frequency with which enrollment reports are

--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ You must
   reports are generated (default `monthly`)
 * `ENROLLMENTREPORTS_K8S_CRONJOB_SCHEDULE` (default `"0 0 1 * *"`,
   that is once a month at midnight, on the first day of the month)
+* `ENROLLMENTREPORTS_K8S_CRONJOB_ENABLE` (default `true`). Set this to
+  `false` to disable (suspend) the generation of enrollment reports.
+* `ENROLLMENTREPORTS_K8S_CRONJOB_STARTING_DEADLINE_SECONDS` (default:
+  `900`). See [the Kubernetes
+  documentation](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#starting-deadline)
+  for details on job start deadlines.
 
 
 ## License

--- a/tutorenrollmentreports/patches/k8s-jobs
+++ b/tutorenrollmentreports/patches/k8s-jobs
@@ -7,6 +7,8 @@ metadata:
     app.kubernetes.io/component: cronjob
 spec:
   schedule: '{{ ENROLLMENTREPORTS_K8S_CRONJOB_SCHEDULE }}'
+  startingDeadlineSeconds: {{ ENROLLMENTREPORTS_K8S_CRONJOB_STARTING_DEADLINE_SECONDS }}
+  suspend: {% if ENROLLMENTREPORTS_K8S_CRONJOB_ENABLE %}false{% else %}true{% endif %}
   jobTemplate:
     spec:
       template:

--- a/tutorenrollmentreports/plugin.py
+++ b/tutorenrollmentreports/plugin.py
@@ -19,7 +19,9 @@ config = {
         "REVISION": "main",
         "MAIL_FROM": "{{ SMTP_USERNAME }}",
         "FREQUENCY": "monthly",
+        "K8S_CRONJOB_ENABLE": True,
         "K8S_CRONJOB_SCHEDULE": "0 0 1 * *",
+        "K8S_CRONJOB_STARTING_DEADLINE_SECONDS": 900,
     },
 }
 


### PR DESCRIPTION
Previously we relied on the existence of the schedule configuration parameters to add or remove the corresponding CronJob. But, if a CronJob is already defined, removing its manifest does not deactivate it. To deactivate a CronJob we need to suspend it.  Add    `ENROLLMENTREPORTS_K8S_CRONJOB_ENABLE` to set the `.spec.suspend` field in the CronJob manifest. We also need to set `.spec.startingDeadlineSeconds` to prevent the missed jobs to be immediately scheduled when `.spec.suspend` is toggled from `true` to `false`.

Reference:
https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/

