### PR TITLE
Fix GitHub Actions workflow

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -16,9 +16,13 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
+      with:
+        # Checkout a pull request's HEAD commit instead of the merge
+        # commit, so that gitlint lints the correct commit message.
+        ref: ${{ github.event.pull_request.head.sha }}
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies


### PR DESCRIPTION
Bump actions to their latest releases:
* `checkout` to v3
* `setup-python` to v4

Also, set the `ref` parameter for the `checkout` option so that `gitlint` can lint the correct commit on a PR.