### PR TITLE
feat: Select a matching version of the Ansible playbooks by default

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -2,7 +2,7 @@
 commit = True
 tag = True
 message = build: Version {new_version}
-current_version = 2.0.0
+current_version = 2.1.0
 
 [bumpversion:file:CHANGELOG.md]
 search = Unreleased

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## Version 2.1.0 (2023-04-21)
 
 * Clone a revision from the Ansible role repo that matches the plugin
   version. That is, for version 2.1.0 of the plugin, clone the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+* Clone a revision from the Ansible role repo that matches the plugin
+  version. That is, for version 2.1.0 of the plugin, clone the
+  `v2.1.0` tag of the Ansible role repo (unless overridden with
+  `ENROLLMENTREPORTS_REVISION`).
+
 ## Version 2.0.0 (2023-03-15)
 
 * Add support for Tutor 15 and Open edX Olive.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ appropriate one:
 
 ## Installation
 
-    pip install git+https://github.com/hastexo/tutor-contrib-enrollmentreports@v2.0.0
+    pip install git+https://github.com/hastexo/tutor-contrib-enrollmentreports@v2.1.0
 
 ## Usage
 

--- a/tutorenrollmentreports/plugin.py
+++ b/tutorenrollmentreports/plugin.py
@@ -16,7 +16,7 @@ config = {
         "VERSION": __version__,
         "DOCKER_IMAGE": "{{ DOCKER_REGISTRY }}enrollmentreports:{{ ENROLLMENTREPORTS_VERSION }}",  # noqa: E501
         "REPOSITORY": "https://github.com/hastexo/ansible-role-enrollmentreports.git",  # noqa: E501
-        "REVISION": "main",
+        "REVISION": f"v{__version__}",
         "MAIL_FROM": "{{ SMTP_USERNAME }}",
         "FREQUENCY": "monthly",
         "K8S_CRONJOB_ENABLE": True,


### PR DESCRIPTION
Without this change, the version to use when cloning the Ansible playbooks is the repository's `main` branch.

This means that an image file built for a specific version of this plugin may differ in functionality, based on the state of the playbook repo's `main` branch at build time.

Thus, change the default version to be cloned to match that of this plugin. For example, for the 2.0.1 version of this plugin, clone the `v2.0.1` tag of the playbook branch by default. This can be overridden by setting `ENROLLMENTREPORTS_REVISION` in `config.yml`, just as before.

This means that whenever we make a change to the plugin *or* the playbooks, we need to bump the tag in both, which ensures that they always match correctly.