### PR TITLE
feat: Support Tutor 16 and Open edX Palm

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -13,6 +13,7 @@ jobs:
           - '3.8'
           - '3.9'
           - '3.10'
+          - '3.11'
 
     steps:
     - name: Check out code

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,3 +34,10 @@ py310:
   script:
     - pip install tox
     - tox -e py310,flake8
+
+py311:
+  image: python:3.11
+  stage: build
+  script:
+    - pip install tox
+    - tox -e gitlint,py311,flake8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* [Enhancement] Support Tutor 16, Open edX Palm and Python 3.11.
+
 ## Version 2.1.0 (2023-04-21)
 
 * Clone a revision from the Ansible role repo that matches the plugin

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ appropriate one:
 | Maple            | `>=13.2, <14`[^1] | `maple`       | 0.1.x          |
 | Nutmeg           | `>=14.0, <15`     | `nutmeg`      | 1.x.x          |
 | Olive            | `>=15.0, <16`     | `main`        | 2.x.x          |
+| Palm             | `>=16.0, <17`     | `main`        | 2.x.x          |
 
 [^1]: For Open edX Maple and Tutor 13, you must run version 13.2.0 or
 ￼   later. That is because this plugin uses the Tutor v1 plugin API,

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
     python_requires=">=3.6",
-    install_requires=["tutor <16, >=15.0.0"],
+    install_requires=["tutor <17, >=15.0.0"],
     setup_requires=["setuptools-scm"],
     entry_points={
         "tutor.plugin.v1": [
@@ -41,5 +41,6 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 [tox]
-envlist = gitlint,py{38,39},flake8
+envlist = gitlint,py{38,39,310,311},flake8
 
 [gh-actions]
 python =
     3.8: gitlint,py38,flake8
     3.9: gitlint,py39,flake8
     3.10: gitlint,py310,flake8
+    3.11: gitlint,py311,flake8
 
 [flake8]
 ignore = E124,W504


### PR DESCRIPTION
* Update the install_requires list to support Tutor 16. Also, update the README accordingly.

* Add the versions of python supported to match those supported by tutor.