### PR TITLE
feat: Support Python 3.12

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -14,6 +14,7 @@ jobs:
           - '3.9'
           - '3.10'
           - '3.11'
+          - '3.12'
 
     steps:
     - name: Check out code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+* [Enhancement] Support Python 3.12.
+
 ## Version 2.3.0 (2024-01-12)
 
 * [Enhancement] Support Tutor 17 and Open edX Quince.

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = gitlint,py{38,39,310,311},flake8
+envlist = gitlint,py{38,39,310,311,312},flake8
 
 [gh-actions]
 python =
@@ -7,6 +7,7 @@ python =
     3.9: gitlint,py39,flake8
     3.10: gitlint,py310,flake8
     3.11: gitlint,py311,flake8
+    3.12: gitlint,py312,flake8
 
 [flake8]
 ignore = E124,W504

--- a/tutorenrollmentreports/__about__.py
+++ b/tutorenrollmentreports/__about__.py
@@ -1,9 +1,8 @@
-import pkg_resources
+from importlib import metadata
 # __version__ attribute as suggested by (deferred) PEP 396:
 # https://www.python.org/dev/peps/pep-0396/
 #
 # Single-source package definition as suggested (among several
 # options) by:
 # https://packaging.python.org/guides/single-sourcing-package-version/
-__version__ = pkg_resources.get_distribution(
-    'tutor-contrib-enrollmentreports').version
+__version__ = metadata.version('tutor-contrib-enrollmentreports')

--- a/tutorenrollmentreports/plugin.py
+++ b/tutorenrollmentreports/plugin.py
@@ -1,7 +1,10 @@
 from .__about__ import __version__
 from glob import glob
 import os
-import pkg_resources
+# When Tutor drops support for Python 3.8, we'll need to update this to:
+# from importlib import resources as importlib_resources
+# See: https://github.com/overhangio/tutor/issues/966#issuecomment-1938681102
+import importlib_resources
 import click
 from tutor import hooks
 from tutor import config as tutor_config
@@ -56,7 +59,7 @@ def enrollmentreports(context):
 
 # Add the "templates" folder as a template root
 hooks.Filters.ENV_TEMPLATE_ROOTS.add_item(
-    pkg_resources.resource_filename("tutorenrollmentreports", "templates")
+    str(importlib_resources.files("tutorenrollmentreports") / "templates")
 )
 # Render the "build" and "apps" folders
 hooks.Filters.ENV_TEMPLATE_TARGETS.add_items(
@@ -66,12 +69,9 @@ hooks.Filters.ENV_TEMPLATE_TARGETS.add_items(
     ],
 )
 # Load patches from files
-for path in glob(
-    os.path.join(
-        pkg_resources.resource_filename("tutorenrollmentreports", "patches"),
-        "*",
-    )
-):
+for path in glob(str(importlib_resources.files(
+        "tutorenrollmentreports") / "patches" / "*")):
+
     with open(path, encoding="utf-8") as patch_file:
         hooks.Filters.ENV_PATCHES.add_item(
             (os.path.basename(path), patch_file.read())


### PR DESCRIPTION
* Replace the use of pkg_resources (from setuptools, which is no longer included in virtual environments as of 3.12) with importlib.metadata and importlib_resources.

* Add Python 3.12 to the test matrix.