### PR TITLE
fix: Set DEBIAN_FRONTEND to noninteractive

### DIFF
--- a/tutorenrollmentreports/templates/enrollmentreports/build/enrollmentreports/Dockerfile
+++ b/tutorenrollmentreports/templates/enrollmentreports/build/enrollmentreports/Dockerfile
@@ -1,4 +1,6 @@
 FROM ubuntu:22.04
+ENV TZ=Etc/UTC
+ENV DEBIAN_FRONTEND=noninteractive
 RUN mkdir -p /etc/ansible/roles/enrollmentreports /etc/ansible/group_vars
 RUN apt-get update && \
     apt install -y ansible git default-mysql-client rsync


### PR DESCRIPTION
Without this change, the image build process hangs while waiting for input from the Readline frontend, when configuring the tzdata package.

Set the `DEBIAN_FRONTEND` environment variable to `noninteractive` instead.

In addition, explicitly set `TZ` to UTC.