### PR TITLE
feat: Allow to override the base image for builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* [Enhancement] Allow to override the base image for builds.
+
 ## Version 3.2.0 (2025-01-03)
 
 * [Enhancement] Support Tutor 19 and Open edX Sumac.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ You must
 * `ENROLLMENTREPORTS_MAIL_FROM`: the sender address to use on the
   enrollment reports. Defaults to the value of `SMTP_USERNAME`; you
   must override this if you want to use a different sender address.
+* `ENROLLMENTREPORTS_BASE_IMAGE`: the base image for the `Dockerfile`. 
+  (default `docker.io/ubuntu:22.04`)
 * `ENROLLMENTREPORTS_DOCKER_IMAGE`: the Docker image used to spin up
   the job pod (set this to an image reference in your local registry,
   unless your Tutor configuration already sets `DOCKER_REGISTRY` to

--- a/tutorenrollmentreports/plugin.py
+++ b/tutorenrollmentreports/plugin.py
@@ -17,6 +17,7 @@ config = {
     },
     "defaults": {
         "VERSION": __version__,
+        "BASE_IMAGE": "docker.io/ubuntu:22.04",
         "DOCKER_IMAGE": "{{ DOCKER_REGISTRY }}enrollmentreports:{{ ENROLLMENTREPORTS_VERSION }}",  # noqa: E501
         "REPOSITORY": "https://github.com/hastexo/ansible-role-enrollmentreports.git",  # noqa: E501
         "REVISION": f"v{__version__}",

--- a/tutorenrollmentreports/templates/enrollmentreports/build/enrollmentreports/Dockerfile
+++ b/tutorenrollmentreports/templates/enrollmentreports/build/enrollmentreports/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM {{ ENROLLMENTREPORTS_BASE_IMAGE }}
 ENV TZ=Etc/UTC
 ENV DEBIAN_FRONTEND=noninteractive
 RUN mkdir -p /etc/ansible/roles/enrollmentreports /etc/ansible/group_vars


### PR DESCRIPTION
Add a config option `ENROLLMENTREPORTS_BASE_IMAGE` that allows to override the base image for builds.