### PR TITLE
docs: Update CHANGELOG and README in anticipation of 3.6.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -2,7 +2,7 @@
 commit = True
 tag = True
 message = build: Version {new_version}
-current_version = 3.5.0
+current_version = 3.6.0
 
 [bumpversion:file:CHANGELOG.md]
 search = Unreleased

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* [Enhancement] Support the renamed [Stackamole XBlock](https://github.com/cleura/stackamole-xblock) (formerly hastexo XBlock).
+
 ## Version 3.5.0 (2026-01-23)
 
 * [Enhancement] Support Tutor 21 and Open edX Ulmo.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## Version 3.6.0 (2026-06-01)
 
 * [Enhancement] Support the renamed [Stackamole XBlock](https://github.com/cleura/stackamole-xblock) (formerly hastexo XBlock).
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ appropriate one:
 
 ## Installation
 
-    pip install git+https://github.com/cleura/tutor-contrib-enrollmentreports@v3.5.0
+    pip install git+https://github.com/cleura/tutor-contrib-enrollmentreports@v3.6.0
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository was previously hosted under the `hastexo` GitHub organization, a
 
 Version compatibility matrix
 ----------------------------
-￼
+
 You must install a supported release of this plugin to match the Open
 edX and Tutor version you are deploying. If you are installing this
 plugin from a branch in this Git repository, you must select the
@@ -30,12 +30,12 @@ appropriate one:
 | Redwood          | `>=18.0, <19`     | `main`        | `>=3`          |
 | Sumac            | `>=19.0, <20`     | `main`        | `>=3.2.0`      |
 | Teak             | `>=20.0, <21`     | `main`        | `>=3.4.0`      |
-| Ulmo             | `>=21.0, <22`     | `main`        | `>=3.5.0`      |
+| Ulmo[^2]         | `>=21.0, <22`     | `main`        | `>=3.6.0`      |
 
-[^1]: For Open edX Maple and Tutor 13, you must run version 13.2.0 or
-￼   later. That is because this plugin uses the Tutor v1 plugin API,
-￼   [which was introduced with that
-￼   release](https://github.com/overhangio/tutor/blob/master/CHANGELOG.md#v1320-2022-04-24).
+[^1]: For Open edX Maple and Tutor 13, you must run version 13.2.0 or later.      That is because this plugin uses the Tutor v1 plugin API, [which was introduced with that release](https://github.com/overhangio/tutor/blob/master/CHANGELOG.md#v1320-2022-04-24).
+
+[^2]: On Ulmo, version 3.5.0 exists to allow installation together with the `hastexo` XBlock.
+      If your setup uses the renamed `stackamole` XBlock, you should use version 3.6.0 or later.
 
 ## Installation
 


### PR DESCRIPTION
Mention version 3.6.0 for support for the renamed Stackamole XBlock.

See also:
https://github.com/cleura/ansible-role-enrollmentreports/pull/24
